### PR TITLE
Update redirect for www subdomain in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
     {
       "source": "/(.*)",
       "has": [{ "type": "host", "value": "www.gameassetfactory.com" }],
-      "destination": "https://gameassetfactory.com/home/",
+      "destination": "https://gameassetfactory.com/$1",
       "permanent": true
     },
     { "source": "/", "destination": "/home/", "permanent": true }


### PR DESCRIPTION
Changed the redirect destination for the www.gameassetfactory.com host to preserve the original path instead of always redirecting to /home/. This ensures all routes are redirected correctly to the root domain.