### PR TITLE
Remove root URL from sitemap.xml

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://gameassetfactory.com/</loc>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
     <loc>https://gameassetfactory.com/home/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>


### PR DESCRIPTION
The root URL entry (https://gameassetfactory.com/) was removed from sitemap.xml, possibly to avoid duplicate content or to streamline sitemap entries.